### PR TITLE
EV Calculation change

### DIFF
--- a/forge16/src/main/java/com/envyful/ultimate/poke/builder/forge/ui/EditPokemonUI.java
+++ b/forge16/src/main/java/com/envyful/ultimate/poke/builder/forge/ui/EditPokemonUI.java
@@ -673,7 +673,7 @@ public class EditPokemonUI {
                         return;
                     }
 
-                    if (value > 0 && (pokemon.getEVs().getTotal() + value) > 510) {
+                    if (value > 0 && (pokemon.getEVs().getTotal() - pokemon.getEVs().getStat(statsType) + value) > 510) {
                         open(player, pokemon);
                         player.message(UtilChatColour.colour(
                                 UltimatePokeBuilderForge.getInstance().getLocale().getMessages().getEvsMax()));

--- a/forge20/src/main/java/com/envyful/ultimate/poke/builder/forge/ui/EditPokemonUI.java
+++ b/forge20/src/main/java/com/envyful/ultimate/poke/builder/forge/ui/EditPokemonUI.java
@@ -669,7 +669,7 @@ public class EditPokemonUI {
                         return;
                     }
 
-                    if (value > 0 && (pokemon.getEVs().getTotal() + value) > 510) {
+                    if (value > 0 && (pokemon.getEVs().getTotal() - pokemon.getEVs().getStat(statsType) + value) > 510) {
                         open(player, pokemon);
                         player.message(UtilChatColour.colour(
                                 UltimatePokeBuilderForge.getInstance().getLocale().getMessages().getEvsMax()));


### PR DESCRIPTION
Small fix. Currently if you're editing a pokemon with high EVs in one stat and attempt to finish maxing it, the existing check doesn't account for value being the current stat + the desired added amount. 

Now is totalEvs - existingEvCount + (existingEv + addedEv = value) > 510